### PR TITLE
Fix union of projection when there are multiple dot notation fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-collection-helpers",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "A package to provide helper functionality for other packages that need mongo projections and test helpers",
   "type": "module",
   "main": "./lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -386,16 +386,16 @@ export function unionOfProjections<TSchema extends Document>(projections: Projec
 
     // this is where we deal with the mixture of dot and nested keys.
     const keys = Object.keys(result).sort((key1, key2) => key1.split(".").length - key2.split(".").length);
-    const prefixes = new Set<string>();
+    const resultKeys = new Set(keys);
     keys.forEach((key) => {
       const keyParts = key.split(".");
-      for (let i = 1; i <= keyParts.length; i++) {
+      for (let i = 1; i < keyParts.length; i++) {
         const prefix = keyParts.slice(0, i).join(".");
-        if (prefixes.has(prefix)) {
+        if (resultKeys.has(prefix)) {
           delete result[key];
+          resultKeys.delete(key);
           break;
         }
-        prefixes.add(prefix);
       }
     })
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -299,4 +299,22 @@ describe("unionOfProjections", () => {
       { a: 1 }
     );
   });
+  it("Should work with identical nested projections", () => {
+    assert.deepEqual(
+      unionOfProjections([
+        { "context.a": 1, "context.b": 1 },
+        { "context.a": 1, "context.b": 1 }
+      ]),
+      { "context.a": 1, "context.b": 1 }
+    );
+  });
+  it("Should subsume dot-notation nested key when broader key exists", () => {
+    assert.deepEqual(
+      unionOfProjections([
+        { "context.a": 1 },
+        { context: 1 }
+      ]),
+      { context: 1 }
+    );
+  });
 });


### PR DESCRIPTION
`{ context: 1}, { "context.a": 1 }` -> `{ context: 1 }`
`{ "context.a": 1 }, { context: 1}` -> `{ context: 1 }`
`{ "context.a": 1 }, { "context.b": 1}` -> `{ "context.a": 1, "context.b": 1 }`
